### PR TITLE
feat: Allow {% include %} to take a variable name

### DIFF
--- a/lib/liquid/tags/include.js
+++ b/lib/liquid/tags/include.js
@@ -7,7 +7,7 @@ module.exports = (function (superClass) {
 
   extend(Include, superClass)
 
-  Syntax = /((?:{{2}\s?)?[a-z0-9/\\_-]+(?:\s?}{2})?)/i
+  Syntax = /((?:{{2}\s?)?[a-z0-9/\\_.-]+(?:\s?}{2})?)/i
 
   SyntaxHelp = "Syntax Error in 'include' - Valid syntax: include [templateName]"
 

--- a/lib/liquid/tags/include.js
+++ b/lib/liquid/tags/include.js
@@ -7,7 +7,7 @@ module.exports = (function (superClass) {
 
   extend(Include, superClass)
 
-  Syntax = /([a-z0-9/\\_-]+)/i
+  Syntax = /((?:{{2}\s?)?[a-z0-9/\\_-]+(?:\s?}{2})?)/i
 
   SyntaxHelp = "Syntax Error in 'include' - Valid syntax: include [templateName]"
 
@@ -18,14 +18,25 @@ module.exports = (function (superClass) {
       throw new Liquid.SyntaxError(SyntaxHelp)
     }
     this.filepath = match[1]
-    this.subTemplate = template.engine.fileSystem.readTemplateFile(this.filepath).then(function (src) {
-      return template.engine.parse(src)
-    })
+
+    this.subTemplate = async function (context) {
+      if (this.filepath.startsWith('{{') && this.filepath.endsWith('}}')) {
+        this.filepath = await context.get(this.filepath)
+      }
+
+      return template
+        .engine
+        .fileSystem
+        .readTemplateFile(this.filepath)
+        .then(function (src) {
+          return template.engine.parse(src)
+        })
+    }
     Include.__super__.constructor.apply(this, arguments)
   }
 
   Include.prototype.render = function (context) {
-    return this.subTemplate.then(function (i) {
+    return this.subTemplate(context).then(function (i) {
       return i.render(context)
     })
   }

--- a/lib/liquid/tags/include.js
+++ b/lib/liquid/tags/include.js
@@ -28,17 +28,14 @@ module.exports = (function (superClass) {
         .engine
         .fileSystem
         .readTemplateFile(this.filepath)
-        .then(function (src) {
-          return template.engine.parse(src)
-        })
+        .then(src => template.engine.parse(src))
     }
     Include.__super__.constructor.apply(this, arguments)
   }
 
-  Include.prototype.render = function (context) {
-    return this.subTemplate(context).then(function (i) {
-      return i.render(context)
-    })
+  Include.prototype.render = async function (context) {
+    const template = await this.subTemplate(context)
+    return template.render(context)
   }
 
   return Include

--- a/test/liquid.js
+++ b/test/liquid.js
@@ -63,14 +63,19 @@ describe('Liquid', function () {
       return expect(this.engine.parse("{% include 'test/fixtures/include' %}")).to.be.fulfilled.then(template => expect(template.root.nodelist[0]).to.be.instanceOf(Liquid.Include))
     })
 
-    it('parses includes with a variable for the path', function () {
-      this.engine.registerFileSystem(new Liquid.LocalFileSystem('./'))
-      return expect(this.engine.parse("{% include {{ path }} %}", { path: 'test/fixtures/include' })).to.be.fulfilled.then(template => expect(template.root.nodelist[0]).to.be.instanceOf(Liquid.Include))
-    })
-
     it('parses includes and renders the template with the correct context', function () {
       this.engine.registerFileSystem(new Liquid.LocalFileSystem('./test'))
       return expect(this.engine.parseAndRender("{% include 'fixtures/include' %}", { name: 'Josh' })).to.be.fulfilled.then(output => expect(output).to.eq('Josh'))
+    })
+
+    it('parses includes with a variable for the path', function () {
+      this.engine.registerFileSystem(new Liquid.LocalFileSystem('./'))
+      return expect(this.engine.parse("{% include {{ path }} %}")).to.be.fulfilled.then(template => expect(template.root.nodelist[0]).to.be.instanceOf(Liquid.Include))
+    })
+
+    it('parses includes with a variable for a the path and renders the template with the correct context', function () {
+      this.engine.registerFileSystem(new Liquid.LocalFileSystem('./test'))
+      return expect(this.engine.parseAndRender("{% include {{ path }} %}", { name: 'Josh', path: 'fixtures/include' })).to.be.fulfilled.then(output => expect(output).to.eq('Josh'))
     })
 
     it('parses nested-includes and renders the template with the correct context', function () {

--- a/test/liquid.js
+++ b/test/liquid.js
@@ -63,6 +63,11 @@ describe('Liquid', function () {
       return expect(this.engine.parse("{% include 'test/fixtures/include' %}")).to.be.fulfilled.then(template => expect(template.root.nodelist[0]).to.be.instanceOf(Liquid.Include))
     })
 
+    it('parses includes with a variable for the path', function () {
+      this.engine.registerFileSystem(new Liquid.LocalFileSystem('./'))
+      return expect(this.engine.parse("{% include {{ path }} %}", { path: 'test/fixtures/include' })).to.be.fulfilled.then(template => expect(template.root.nodelist[0]).to.be.instanceOf(Liquid.Include))
+    })
+
     it('parses includes and renders the template with the correct context', function () {
       this.engine.registerFileSystem(new Liquid.LocalFileSystem('./test'))
       return expect(this.engine.parseAndRender("{% include 'fixtures/include' %}", { name: 'Josh' })).to.be.fulfilled.then(output => expect(output).to.eq('Josh'))

--- a/test/liquid.js
+++ b/test/liquid.js
@@ -73,9 +73,14 @@ describe('Liquid', function () {
       return expect(this.engine.parse("{% include {{ path }} %}")).to.be.fulfilled.then(template => expect(template.root.nodelist[0]).to.be.instanceOf(Liquid.Include))
     })
 
-    it('parses includes with a variable for a the path and renders the template with the correct context', function () {
+    it('parses includes with a variable for a path and renders the template with the correct context', function () {
       this.engine.registerFileSystem(new Liquid.LocalFileSystem('./test'))
       return expect(this.engine.parseAndRender("{% include {{ path }} %}", { name: 'Josh', path: 'fixtures/include' })).to.be.fulfilled.then(output => expect(output).to.eq('Josh'))
+    })
+
+    it('parses includes with a variable for a nested path and renders the template with the correct context', function () {
+      this.engine.registerFileSystem(new Liquid.LocalFileSystem('./test'))
+      return expect(this.engine.parseAndRender("{% include {{ paths.example }} %}", { name: 'Josh', paths: { example: 'fixtures/include' } })).to.be.fulfilled.then(output => expect(output).to.eq('Josh'))
     })
 
     it('parses nested-includes and renders the template with the correct context', function () {


### PR DESCRIPTION
This PR enables the `include` tag to take a variable as the path argment:

```liquid
{% include {{ path_to_file }} %}
```

This is in-line with the Ruby implementation of Liquid, per [these Jekyll docs](https://jekyllrb.com/docs/includes/). I added two tests for this behavior, one to ensure that parsing is unchanged, and one to test that rendering works as expected.

One note - I wrote this repo's first ever `async/await` function (at least outside of tests). Do we have any information about support Node versions? Do we care that this ostensibly bumps the minimum version to, I think, Node 10?