### PR TITLE
refactor: Tags to classes

### DIFF
--- a/lib/liquid/engine.js
+++ b/lib/liquid/engine.js
@@ -17,6 +17,8 @@ module.exports = Liquid.Engine = (function () {
         return false
       } else if (klass === ofKlass) {
         return true
+      } else if (tag.prototype instanceof Liquid.Tag) {
+        return true
       } else {
         return isSubclassOf((ref = klass.__super__) != null ? ref.constructor : void 0, ofKlass)
       }

--- a/lib/liquid/engine.js
+++ b/lib/liquid/engine.js
@@ -17,7 +17,7 @@ module.exports = Liquid.Engine = (function () {
         return false
       } else if (klass === ofKlass) {
         return true
-      } else if (tag.prototype instanceof Liquid.Tag) {
+      } else if (klass instanceof Liquid.Tag) {
         return true
       } else {
         return isSubclassOf((ref = klass.__super__) != null ? ref.constructor : void 0, ofKlass)

--- a/lib/liquid/tags/assign.js
+++ b/lib/liquid/tags/assign.js
@@ -1,31 +1,22 @@
-const extend = function (child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key] } function Ctor () { this.constructor = child } Ctor.prototype = parent.prototype; child.prototype = new Ctor(); child.__super__ = parent.prototype; return child }
-const hasProp = {}.hasOwnProperty
 const Liquid = require('../../liquid')
 
-module.exports = (function (superClass) {
-  var Syntax, SyntaxHelp
+const SyntaxHelp = "Syntax Error in 'assign' - Valid syntax: assign [var] = [source]"
+const Syntax = RegExp('((?:' + Liquid.VariableSignature.source + ')+)\\s*=\\s*(.*)\\s*')
 
-  extend(Assign, superClass)
-
-  SyntaxHelp = "Syntax Error in 'assign' - Valid syntax: assign [var] = [source]"
-
-  Syntax = RegExp('((?:' + Liquid.VariableSignature.source + ')+)\\s*=\\s*(.*)\\s*')
-
-  function Assign (template, tagName, markup) {
-    var match = Syntax.exec(markup)
+module.exports = class Assign extends Liquid.Tag {
+  constructor (template, tagName, markup) {
+    super(template, tagName, markup)
+    const match = Syntax.exec(markup)
     if (match) {
       this.to = match[1]
       this.from = new Liquid.Variable(match[2])
     } else {
       throw new Liquid.SyntaxError(SyntaxHelp)
     }
-    Assign.__super__.constructor.apply(this, arguments)
   }
 
-  Assign.prototype.render = function (context) {
+  async render (context) {
     context.lastScope()[this.to] = this.from.render(context)
-    return Assign.__super__.render.call(this, context)
+    return super.render.call(this, context)
   }
-
-  return Assign
-})(Liquid.Tag)
+}

--- a/lib/liquid/tags/capture.js
+++ b/lib/liquid/tags/capture.js
@@ -1,37 +1,23 @@
-const extend = function (child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key] } function Ctor () { this.constructor = child } Ctor.prototype = parent.prototype; child.prototype = new Ctor(); child.__super__ = parent.prototype; return child }
-const hasProp = {}.hasOwnProperty
 const Liquid = require('../../liquid')
 
-module.exports = (function (superClass) {
-  var Syntax, SyntaxHelp
+const Syntax = /(\w+)/
+const SyntaxHelp = "Syntax Error in 'capture' - Valid syntax: capture [var]"
 
-  extend(Capture, superClass)
-
-  Syntax = /(\w+)/
-
-  SyntaxHelp = "Syntax Error in 'capture' - Valid syntax: capture [var]"
-
-  function Capture (template, tagName, markup) {
-    var match
-    match = Syntax.exec(markup)
+module.exports = class Capture extends Liquid.Block {
+  constructor (template, tagName, markup) {
+    super(template, tagName, markup)
+    const match = Syntax.exec(markup)
     if (match) {
       this.to = match[1]
     } else {
       throw new Liquid.SyntaxError(SyntaxHelp)
     }
-    Capture.__super__.constructor.apply(this, arguments)
   }
 
-  Capture.prototype.render = function (context) {
-    return Capture.__super__.render.apply(this, arguments).then((function (_this) {
-      return function (chunks) {
-        var output
-        output = Liquid.Helpers.toFlatString(chunks)
-        context.lastScope()[_this.to] = output
-        return ''
-      }
-    })(this))
+  async render (context) {
+    const chunks = await super.render(context)
+    const output = Liquid.Helpers.toFlatString(chunks)
+    context.lastScope()[this.to] = output
+    return ''
   }
-
-  return Capture
-})(Liquid.Block)
+}

--- a/lib/liquid/tags/case.js
+++ b/lib/liquid/tags/case.js
@@ -1,84 +1,65 @@
-const extend = function (child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key] } function Ctor () { this.constructor = child } Ctor.prototype = parent.prototype; child.prototype = new Ctor(); child.__super__ = parent.prototype; return child }
-const hasProp = {}.hasOwnProperty
 const Liquid = require('../../liquid')
 const PromiseReduce = require('../../promise_reduce')
 
-module.exports = (function (superClass) {
-  extend(Case, superClass)
+const SyntaxHelp = "Syntax Error in tag 'case' - Valid syntax: case [expression]"
+const Syntax = RegExp('(' + Liquid.QuotedFragment.source + ')')
+const WhenSyntax = RegExp('(' + Liquid.QuotedFragment.source + ')(?:(?:\\s+or\\s+|\\s*\\,\\s*)(' + Liquid.QuotedFragment.source + '))?')
 
-  const SyntaxHelp = "Syntax Error in tag 'case' - Valid syntax: case [expression]"
-  const Syntax = RegExp('(' + Liquid.QuotedFragment.source + ')')
-  const WhenSyntax = RegExp('(' + Liquid.QuotedFragment.source + ')(?:(?:\\s+or\\s+|\\s*\\,\\s*)(' + Liquid.QuotedFragment.source + '))?')
-
-  function Case (template, tagName, markup) {
-    var match
-    this.blocks = []
-    match = Syntax.exec(markup)
+module.exports = class Case extends Liquid.Block {
+  constructor (template, tagName, markup) {
+    super(template, tagName, markup)
+    const match = Syntax.exec(markup)
     if (!match) {
       throw new Liquid.SyntaxError(SyntaxHelp)
     }
-    this.markup = markup
-    Case.__super__.constructor.apply(this, arguments)
+    this.blocks = []
   }
 
-  Case.prototype.unknownTag = function (tag, markup) {
+  unknownTag (tag, markup) {
     if (tag === 'when' || tag === 'else') {
       return this.pushBlock(tag, markup)
     } else {
-      return Case.__super__.unknownTag.apply(this, arguments)
+      return super.unknownTag(tag, markup)
     }
   }
 
-  Case.prototype.render = function (context) {
-    return context.stack((function (_this) {
-      return function () {
-        return PromiseReduce(_this.blocks, function (chosenBlock, block) {
-          if (chosenBlock != null) {
-            return chosenBlock
-          }
-          return Promise.resolve().then(function () {
-            return block.evaluate(context)
-          }).then(function (ok) {
-            if (ok) {
-              return block
-            }
-          })
-        }, null).then(function (block) {
-          if (block != null) {
-            return _this.renderAll(block.attachment, context)
-          } else {
-            return ''
-          }
-        })
-      }
-    })(this))
-  }
-
-  Case.prototype.pushBlock = function (tag, markup) {
-    var block, expressions, i, len, nodelist, ref, results, value
+  pushBlock (tag, markup) {
     if (tag === 'else') {
-      block = new Liquid.ElseCondition()
+      const block = new Liquid.ElseCondition()
       this.blocks.push(block)
       this.nodelist = block.attach([])
       return this.nodelist
-    } else {
-      expressions = Liquid.Helpers.scan(markup, WhenSyntax)
-      nodelist = []
-      ref = expressions[0]
-      results = []
-      for (i = 0, len = ref.length; i < len; i++) {
-        value = ref[i]
-        if (value) {
-          block = new Liquid.Condition(this.markup, '==', value)
-          this.blocks.push(block)
-          results.push(this.nodelist = block.attach(nodelist))
-        } else {
-          results.push(void 0)
-        }
-      }
-      return results
     }
+
+    const expressions = Liquid.Helpers.scan(markup, WhenSyntax)
+    const nodelist = []
+    const ref = expressions[0]
+    const results = []
+
+    for (const value of ref) {
+      if (value) {
+        const block = new Liquid.Condition(this.markup, '==', value)
+        this.blocks.push(block)
+        results.push(this.nodelist = block.attach(nodelist))
+      } else {
+        results.push(void 0)
+      }
+    }
+
+    return results
   }
 
-  return Case
-})(Liquid.Block)
+  async render (context) {
+    const block = await PromiseReduce(this.blocks, async (chosenBlock, block) => {
+      if (chosenBlock != null) return chosenBlock
+      const ok = await block.evaluate(context)
+      if (ok) return block
+    }, null)
+
+    return context.stack(() => {
+      return block != null
+        ? this.renderAll(block.attachment, context)
+        : ''
+    })
+  }
+}

--- a/lib/liquid/tags/comment.js
+++ b/lib/liquid/tags/comment.js
@@ -1,17 +1,7 @@
-const extend = function (child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key] } function Ctor () { this.constructor = child } Ctor.prototype = parent.prototype; child.prototype = new Ctor(); child.__super__ = parent.prototype; return child }
-const hasProp = {}.hasOwnProperty
 const Raw = require('./raw')
 
-module.exports = (function (superClass) {
-  extend(Comment, superClass)
-
-  function Comment () {
-    return Comment.__super__.constructor.apply(this, arguments)
-  }
-
-  Comment.prototype.render = function () {
+module.exports = class Comment extends Raw {
+  render () {
     return ''
   }
-
-  return Comment
-})(Raw)
+}

--- a/lib/liquid/tags/decrement.js
+++ b/lib/liquid/tags/decrement.js
@@ -1,22 +1,16 @@
-const extend = function (child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key] } function Ctor () { this.constructor = child } Ctor.prototype = parent.prototype; child.prototype = new Ctor(); child.__super__ = parent.prototype; return child }
-const hasProp = {}.hasOwnProperty
 const Liquid = require('../../liquid')
 
-module.exports = (function (superClass) {
-  extend(Decrement, superClass)
-
-  function Decrement (template, tagName, markup) {
+module.exports = class Decrement extends Liquid.Tag {
+  constructor (template, tagName, markup) {
+    super(template, tagName, markup)
     this.variable = markup.trim()
-    Decrement.__super__.constructor.apply(this, arguments)
   }
 
-  Decrement.prototype.render = function (context) {
-    var base, name, value
-    value = (base = context.environments[0])[name = this.variable] || (base[name] = 0)
-    value = value - 1
+  render (context) {
+    const base = context.environments[0]
+    if (!base[this.variable]) base[this.variable] = 0
+    const value = base[this.variable] - 1
     context.environments[0][this.variable] = value
     return value.toString()
   }
-
-  return Decrement
-})(Liquid.Tag)
+}

--- a/lib/liquid/tags/for.js
+++ b/lib/liquid/tags/for.js
@@ -1,121 +1,39 @@
-const extend = function (child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key] } function Ctor () { this.constructor = child } Ctor.prototype = parent.prototype; child.prototype = new Ctor(); child.__super__ = parent.prototype; return child }
-const hasProp = {}.hasOwnProperty
 const Liquid = require('../../liquid')
 const PromiseReduce = require('../../promise_reduce')
 const Iterable = require('../iterable')
 
-module.exports = (function (superClass) {
-  var Syntax, SyntaxHelp
+const SyntaxHelp = "Syntax Error in 'for loop' - Valid syntax: for [item] in [collection]"
+const Syntax = RegExp('(\\w+)\\s+in\\s+((?:' + Liquid.QuotedFragment.source + ')+)\\s*(reversed)?')
 
-  extend(For, superClass)
-
-  SyntaxHelp = "Syntax Error in 'for loop' - Valid syntax: for [item] in [collection]"
-
-  Syntax = RegExp('(\\w+)\\s+in\\s+((?:' + Liquid.QuotedFragment.source + ')+)\\s*(reversed)?')
-
-  function For (template, tagName, markup) {
-    var match
-    match = Syntax.exec(markup)
-    if (match) {
-      this.variableName = match[1]
-      this.collectionName = match[2]
-      this.registerName = match[1] + '=' + match[2]
-      this.reversed = match[3]
-      this.attributes = {}
-      Liquid.Helpers.scan(markup, Liquid.TagAttributes).forEach((function (_this) {
-        return function (attr) {
-          _this.attributes[attr[0]] = attr[1]
-        }
-      })(this))
-    } else {
+module.exports = class For extends Liquid.Block {
+  constructor (template, tagName, markup) {
+    super(template, tagName, markup)
+    const match = Syntax.exec(markup)
+    if (!match) {
       throw new Liquid.SyntaxError(SyntaxHelp)
     }
+
+    this.variableName = match[1]
+    this.collectionName = match[2]
+    this.registerName = match[1] + '=' + match[2]
+    this.reversed = match[3]
+    this.attributes = {}
     this.nodelist = this.forBlock = []
-    For.__super__.constructor.apply(this, arguments)
+
+    Liquid.Helpers.scan(markup, Liquid.TagAttributes).forEach(attr => {
+      this.attributes[attr[0]] = attr[1]
+    })
   }
 
-  For.prototype.unknownTag = function (tag, markup) {
+  unknownTag (tag, markup) {
     if (tag !== 'else') {
-      return For.__super__.unknownTag.apply(this, arguments)
+      return super.unknownTag(tag, markup)
     }
     this.nodelist = this.elseBlock = []
     return this.nodelist
   }
 
-  For.prototype.render = function (context) {
-    var base;
-    (base = context.registers)['for'] || (base['for'] = {})
-    return Promise.resolve(context.get(this.collectionName)).then((function (_this) {
-      return function (collection) {
-        var from, k, limit, to, v
-        if (collection != null ? collection.forEach : void 0) {
-
-        } else if (collection instanceof Object) {
-          collection = (function () {
-            var results
-            results = []
-            for (k in collection) {
-              if (!hasProp.call(collection, k)) continue
-              v = collection[k]
-              results.push([k, v])
-            }
-            return results
-          })()
-        } else {
-          return _this.renderElse(context)
-        }
-        from = _this.attributes.offset === 'continue' ? Number(context.registers['for'][_this.registerName]) || 0 : Number(_this.attributes.offset) || 0
-        limit = _this.attributes.limit
-        to = limit ? Number(limit) + from : null
-        return _this.sliceCollection(collection, from, to).then(function (segment) {
-          var length
-          if (segment.length === 0) {
-            return _this.renderElse(context)
-          }
-          if (_this.reversed) {
-            segment.reverse()
-          }
-          length = segment.length
-          context.registers['for'][_this.registerName] = from + segment.length
-          return context.stack(function () {
-            return PromiseReduce(segment, function (output, item, index) {
-              context.set(_this.variableName, item)
-              context.set('forloop', {
-                name: _this.registerName,
-                length: length,
-                index: index + 1,
-                index0: index,
-                rindex: length - index,
-                rindex0: length - index - 1,
-                first: index === 0,
-                last: index === length - 1
-              })
-              return Promise.resolve().then(function () {
-                return _this.renderAll(_this.forBlock, context)
-              }).then(function (rendered) {
-                output.push(rendered)
-                return output
-              })['catch'](function (e) {
-                output.push(context.handleError(e))
-                return output
-              })
-            }, [])
-          })
-        })
-      }
-    })(this))
-  }
-
-  For.prototype.sliceCollection = function (collection, from, to) {
-    var args, ref
-    args = [from]
-    if (to != null) {
-      args.push(to)
-    }
-    return (ref = Iterable.cast(collection)).slice.apply(ref, args)
-  }
-
-  For.prototype.renderElse = function (context) {
+  renderElse (context) {
     if (this.elseBlock) {
       return this.renderAll(this.elseBlock, context)
     } else {
@@ -123,5 +41,77 @@ module.exports = (function (superClass) {
     }
   }
 
-  return For
-})(Liquid.Block)
+  sliceCollection (collection, from, to) {
+    const args = [from]
+    if (to != null) {
+      args.push(to)
+    }
+
+    const ref = Iterable.cast(collection)
+    return ref.slice.apply(ref, args)
+  }
+
+  async render (context) {
+    if (!context.registers.for) context.registers.for = {}
+    let collection = await context.get(this.collectionName)
+
+    if (collection != null ? collection.forEach : void 0) {
+
+    } else if (collection instanceof Object) {
+      const results = []
+
+      for (const key in collection) {
+        if (!Object.prototype.hasOwnProperty.call(collection, key)) {
+          continue
+        }
+
+        const v = collection[key]
+        results.push([key, v])
+      }
+
+      collection = results
+    } else {
+      return this.renderElse(context)
+    }
+
+    const from = this.attributes.offset === 'continue' ? Number(context.registers.for[this.registerName]) || 0 : Number(this.attributes.offset) || 0
+    const limit = this.attributes.limit
+    const to = limit ? Number(limit) + from : null
+
+    const segment = await this.sliceCollection(collection, from, to)
+    if (segment.length === 0) {
+      return this.renderElse(context)
+    }
+
+    if (this.reversed) {
+      segment.reverse()
+    }
+
+    const length = segment.length
+    context.registers.for[this.registerName] = from + segment.length
+    return context.stack(() => {
+      return PromiseReduce(segment, async (output, item, index) => {
+        context.set(this.variableName, item)
+        context.set('forloop', {
+          name: this.registerName,
+          length: length,
+          index: index + 1,
+          index0: index,
+          rindex: length - index,
+          rindex0: length - index - 1,
+          first: index === 0,
+          last: index === length - 1
+        })
+
+        try {
+          const rendered = await this.renderAll(this.forBlock, context)
+          output.push(rendered)
+        } catch (err) {
+          output.push(context.handleError(err))
+        }
+
+        return output
+      }, [])
+    })
+  }
+}

--- a/lib/liquid/tags/if.js
+++ b/lib/liquid/tags/if.js
@@ -1,98 +1,85 @@
-const extend = function (child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key] } function Ctor () { this.constructor = child } Ctor.prototype = parent.prototype; child.prototype = new Ctor(); child.__super__ = parent.prototype; return child }
-const hasProp = {}.hasOwnProperty
 const Liquid = require('../../liquid')
 const PromiseReduce = require('../../promise_reduce')
 
-module.exports = (function (superClass) {
-  var ExpressionsAndOperators, Syntax, SyntaxHelp
+const SyntaxHelp = "Syntax Error in tag 'if' - Valid syntax: if [expression]"
+const Syntax = RegExp('(' + Liquid.QuotedFragment.source + ')\\s*([=!<>a-z_]+)?\\s*(' + Liquid.QuotedFragment.source + ')?')
+const ExpressionsAndOperators = RegExp('(?:\\b(?:\\s?and\\s?|\\s?or\\s?)\\b|(?:\\s*(?!\\b(?:\\s?and\\s?|\\s?or\\s?)\\b)(?:' + Liquid.QuotedFragment.source + '|\\S+)\\s*)+)')
 
-  extend(If, superClass)
-
-  SyntaxHelp = "Syntax Error in tag 'if' - Valid syntax: if [expression]"
-
-  Syntax = RegExp('(' + Liquid.QuotedFragment.source + ')\\s*([=!<>a-z_]+)?\\s*(' + Liquid.QuotedFragment.source + ')?')
-
-  ExpressionsAndOperators = RegExp('(?:\\b(?:\\s?and\\s?|\\s?or\\s?)\\b|(?:\\s*(?!\\b(?:\\s?and\\s?|\\s?or\\s?)\\b)(?:' + Liquid.QuotedFragment.source + '|\\S+)\\s*)+)')
-
-  function If (template, tagName, markup) {
+module.exports = class If extends Liquid.Block {
+  constructor (template, tagName, markup) {
+    super(template, tagName, markup)
     this.blocks = []
     this.pushBlock('if', markup)
-    If.__super__.constructor.apply(this, arguments)
   }
 
-  If.prototype.unknownTag = function (tag, markup) {
+  unknownTag (tag, markup) {
     if (tag === 'elsif' || tag === 'else') {
       return this.pushBlock(tag, markup)
     } else {
-      return If.__super__.unknownTag.apply(this, arguments)
+      return super.unknownTag(tag, markup)
     }
   }
 
-  If.prototype.render = function (context) {
-    return context.stack((function (_this) {
-      return function () {
-        return PromiseReduce(_this.blocks, function (chosenBlock, block) {
-          if (chosenBlock != null) {
-            return chosenBlock
-          }
-          return Promise.resolve().then(function () {
-            return block.evaluate(context)
-          }).then(function (ok) {
-            if (block.negate) {
-              ok = !ok
-            }
-            if (ok) {
-              return block
-            }
-          })
-        }, null).then(function (block) {
-          if (block != null) {
-            return _this.renderAll(block.attachment, context)
-          } else {
-            return ''
-          }
-        })
+  defineBlock (tag, markup) {
+    if (tag === 'else') {
+      return new Liquid.ElseCondition()
+    }
+
+    const expressions = Liquid.Helpers
+      .scan(markup, ExpressionsAndOperators)
+      .reverse()
+
+    const match = Syntax.exec(expressions.shift())
+    if (!match) {
+      throw new Liquid.SyntaxError(SyntaxHelp)
+    }
+
+    let condition = (function (func, args) {
+      const child = new Liquid.Condition()
+      const result = func.apply(child, args)
+      return Object(result) === result ? result : child
+    })(Liquid.Condition, match.slice(1, 4))
+
+    while (expressions.length > 0) {
+      const operator = String(expressions.shift()).trim()
+      const newMatch = Syntax.exec(expressions.shift())
+      if (!newMatch) {
+        throw new SyntaxError(SyntaxHelp)
       }
-    })(this))
+
+      const newCondition = (function (func, args) {
+        const child = new Liquid.Condition()
+        const result = func.apply(child, args)
+        return Object(result) === result ? result : child
+      })(Liquid.Condition, newMatch.slice(1, 4))
+
+      newCondition[operator].call(newCondition, condition) // eslint-disable-line
+      condition = newCondition
+    }
+
+    return condition
   }
 
-  If.prototype.pushBlock = function (tag, markup) {
-    var block, condition, expressions, match, newCondition, operator
-    block = (function () {
-      if (tag === 'else') {
-        return new Liquid.ElseCondition()
-      } else {
-        expressions = Liquid.Helpers.scan(markup, ExpressionsAndOperators)
-        expressions = expressions.reverse()
-        match = Syntax.exec(expressions.shift())
-        if (!match) {
-          throw new Liquid.SyntaxError(SyntaxHelp)
-        }
-        condition = (function (func, args, Ctor) {
-          Ctor.prototype = func.prototype
-          var child = new Ctor(); var result = func.apply(child, args)
-          return Object(result) === result ? result : child
-        })(Liquid.Condition, match.slice(1, 4), function () {})
-        while (expressions.length > 0) {
-          operator = String(expressions.shift()).trim()
-          match = Syntax.exec(expressions.shift())
-          if (!match) {
-            throw new SyntaxError(SyntaxHelp)
-          }
-          newCondition = (function (func, args, Ctor) {
-            Ctor.prototype = func.prototype
-            var child = new Ctor(); var result = func.apply(child, args)
-            return Object(result) === result ? result : child
-          })(Liquid.Condition, match.slice(1, 4), function () {})
-          newCondition[operator].call(newCondition, condition) // eslint-disable-line
-          condition = newCondition
-        }
-        return condition
-      }
-    })()
+  pushBlock (tag, markup) {
+    const block = this.defineBlock(tag, markup)
     this.blocks.push(block)
     this.nodelist = block.attach([])
   }
 
-  return If
-})(Liquid.Block)
+  async render (context) {
+    const block = await PromiseReduce(this.blocks, async (chosenBlock, block) => {
+      if (chosenBlock != null) return chosenBlock
+      let ok = await block.evaluate(context)
+      if (block.negate) ok = !ok
+      if (ok) return block
+    }, null)
+
+    return context.stack(async () => {
+      if (block != null) {
+        return this.renderAll(block.attachment, context)
+      } else {
+        return ''
+      }
+    })
+  }
+}

--- a/lib/liquid/tags/ifchanged.js
+++ b/lib/liquid/tags/ifchanged.js
@@ -1,31 +1,16 @@
-const extend = function (child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key] } function Ctor () { this.constructor = child } Ctor.prototype = parent.prototype; child.prototype = new Ctor(); child.__super__ = parent.prototype; return child }
-const hasProp = {}.hasOwnProperty
 const Liquid = require('../../liquid')
 
-module.exports = (function (superClass) {
-  extend(IfChanged, superClass)
-
-  function IfChanged () {
-    return IfChanged.__super__.constructor.apply(this, arguments)
-  }
-
-  IfChanged.prototype.render = function (context) {
-    return context.stack((function (_this) {
-      return function () {
-        var rendered
-        rendered = _this.renderAll(_this.nodelist, context)
-        return Promise.resolve(rendered).then(function (output) {
-          output = Liquid.Helpers.toFlatString(output)
-          if (output !== context.registers.ifchanged) {
-            context.registers.ifchanged = output
-            return context.registers.ifchanged
-          } else {
-            return ''
-          }
-        })
+module.exports = class IfChanged extends Liquid.Block {
+  async render (context) {
+    return context.stack(async () => {
+      const rendered = await this.renderAll(this.nodelist, context)
+      const output = Liquid.Helpers.toFlatString(rendered)
+      if (output !== context.registers.ifchanged) {
+        context.registers.ifchanged = output
+        return context.registers.ifchanged
+      } else {
+        return ''
       }
-    })(this))
+    })
   }
-
-  return IfChanged
-})(Liquid.Block)
+}

--- a/lib/liquid/tags/include.js
+++ b/lib/liquid/tags/include.js
@@ -28,7 +28,7 @@ module.exports = class Include extends Liquid.Tag {
   }
 
   async render (context) {
-    const subTemplate = await this.subTemplate()
+    const subTemplate = await this.subTemplate(context)
     return subTemplate.render(context)
   }
 }

--- a/lib/liquid/tags/include.js
+++ b/lib/liquid/tags/include.js
@@ -1,34 +1,30 @@
-const extend = function (child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key] } function Ctor () { this.constructor = child } Ctor.prototype = parent.prototype; child.prototype = new Ctor(); child.__super__ = parent.prototype; return child }
-const hasProp = {}.hasOwnProperty
 const Liquid = require('../../liquid')
 
-module.exports = (function (superClass) {
-  var Syntax, SyntaxHelp
+const Syntax = /([a-z0-9/\\_-]+)/i
+const SyntaxHelp = "Syntax Error in 'include' - Valid syntax: include [templateName]"
 
-  extend(Include, superClass)
+module.exports = class Include extends Liquid.Tag {
+  constructor (template, tagName, markup) {
+    super(template, tagName, markup)
 
-  Syntax = /([a-z0-9/\\_-]+)/i
-
-  SyntaxHelp = "Syntax Error in 'include' - Valid syntax: include [templateName]"
-
-  function Include (template, tagName, markup, tokens) {
-    var match
-    match = Syntax.exec(markup)
+    const match = Syntax.exec(markup)
     if (!match) {
       throw new Liquid.SyntaxError(SyntaxHelp)
     }
+
     this.filepath = match[1]
-    this.subTemplate = template.engine.fileSystem.readTemplateFile(this.filepath).then(function (src) {
-      return template.engine.parse(src)
-    })
-    Include.__super__.constructor.apply(this, arguments)
   }
 
-  Include.prototype.render = function (context) {
-    return this.subTemplate.then(function (i) {
-      return i.render(context)
-    })
+  async subTemplate () {
+    const src = await this.template
+      .engine
+      .fileSystem
+      .readTemplateFile(this.filepath)
+    return this.template.engine.parse(src)
   }
 
-  return Include
-})(Liquid.Tag)
+  async render (context) {
+    const subTemplate = await this.subTemplate()
+    return subTemplate.render(context)
+  }
+}

--- a/lib/liquid/tags/increment.js
+++ b/lib/liquid/tags/increment.js
@@ -1,21 +1,16 @@
-const extend = function (child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key] } function Ctor () { this.constructor = child } Ctor.prototype = parent.prototype; child.prototype = new Ctor(); child.__super__ = parent.prototype; return child }
-const hasProp = {}.hasOwnProperty
 const Liquid = require('../../liquid')
 
-module.exports = (function (superClass) {
-  extend(Increment, superClass)
-
-  function Increment (template, tagName, markup) {
+module.exports = class Increment extends Liquid.Tag {
+  constructor (template, tagName, markup) {
+    super(template, tagName, markup)
     this.variable = markup.trim()
-    Increment.__super__.constructor.apply(this, arguments)
   }
 
-  Increment.prototype.render = function (context) {
-    var base, name, value
-    value = (base = context.environments[0])[name = this.variable] != null ? base[name] : base[name] = 0
+  render (context) {
+    const base = context.environments[0]
+    if (!base[this.variable]) base[this.variable] = 0
+    const value = base[this.variable]
     context.environments[0][this.variable] = value + 1
-    return String(value)
+    return value.toString()
   }
-
-  return Increment
-})(Liquid.Tag)
+}

--- a/lib/liquid/tags/raw.js
+++ b/lib/liquid/tags/raw.js
@@ -1,31 +1,19 @@
-const extend = function (child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key] } function Ctor () { this.constructor = child } Ctor.prototype = parent.prototype; child.prototype = new Ctor(); child.__super__ = parent.prototype; return child }
-const hasProp = {}.hasOwnProperty
 const Liquid = require('../../liquid')
 
-module.exports = (function (superClass) {
-  extend(Raw, superClass)
+module.exports = class Raw extends Liquid.Block {
+  async parse (tokens) {
+    if (tokens.length === 0 || this.ended) {
+      return
+    }
 
-  function Raw () {
-    return Raw.__super__.constructor.apply(this, arguments)
+    const token = tokens.shift()
+    const match = Liquid.Block.FullToken.exec(token.value)
+
+    if ((match != null ? match[1] : void 0) === this.blockDelimiter()) {
+      return this.endTag()
+    }
+
+    this.nodelist.push(token.value)
+    return this.parse(tokens)
   }
-
-  Raw.prototype.parse = function (tokens) {
-    return Promise.resolve().then((function (_this) {
-      return function () {
-        var match, token
-        if (tokens.length === 0 || _this.ended) {
-          return Promise.resolve()
-        }
-        token = tokens.shift()
-        match = Liquid.Block.FullToken.exec(token.value)
-        if ((match != null ? match[1] : void 0) === _this.blockDelimiter()) {
-          return _this.endTag()
-        }
-        _this.nodelist.push(token.value)
-        return _this.parse(tokens)
-      }
-    })(this))
-  }
-
-  return Raw
-})(Liquid.Block)
+}

--- a/lib/liquid/tags/unless.js
+++ b/lib/liquid/tags/unless.js
@@ -1,21 +1,8 @@
-const extend = function (child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key] } function Ctor () { this.constructor = child } Ctor.prototype = parent.prototype; child.prototype = new Ctor(); child.__super__ = parent.prototype; return child }
-const hasProp = {}.hasOwnProperty
 const Liquid = require('../../liquid')
 
-module.exports = (function (superClass) {
-  extend(Unless, superClass)
-
-  function Unless () {
-    return Unless.__super__.constructor.apply(this, arguments)
+module.exports = class Unless extends Liquid.If {
+  async parse (tokens) {
+    await super.parse(tokens)
+    this.blocks[0].negate = true
   }
-
-  Unless.prototype.parse = function () {
-    return Unless.__super__.parse.apply(this, arguments).then((function (_this) {
-      return function () {
-        _this.blocks[0].negate = true
-      }
-    })(this))
-  }
-
-  return Unless
-})(Liquid.If)
+}


### PR DESCRIPTION
This PR converts all of the tags in `lib/liquid/tags/` to ES6 classes, with `async/await` methods instead of wonky Promises. It's going to be pretty difficult to review, because each tag is changed a good deal. I kept the same method names, signatures, etc - but the internals are all slightly different. Mostly I did the following:

* Removed unnecessary closures in favor of using `this` in a more class-y way
* Removed `var ...` in favor of `const` when we actually define the variable

This is all to achieve two things: have a more manageable codebase that we can make changes to, and to improve performance by removing unnecessary assignments (like the `extend` function, closures, etc).

The one change that I had to make outside of specific tags was to `engine.js`, to properly check for subclasses.

@zeke - how do you feel about this? Do you think we _should_ do this kind of refactoring (I don't mind taking it on)? Are we confident enough in the tests to know that this is a safe refactor?

If yes - how to we want to roll it out? I'd like to do it all at once as one big new version with the rest of the codebase getting udpates, but semantic-release will ship it per PR.
