### PR TITLE
fix: Don't throw an error if `render` for tries to render a falsy value

### DIFF
--- a/lib/liquid/tags/render.js
+++ b/lib/liquid/tags/render.js
@@ -74,6 +74,7 @@ module.exports = class Render extends Liquid.Tag {
   async renderAll (subTemplate, variables) {
     const renders = []
     const value = variables[this.operatorKey]
+    if (!value) return
     const length = value.length
 
     for (let index = 0; index < length; index++) {

--- a/test/blocks.js
+++ b/test/blocks.js
@@ -207,6 +207,12 @@ describe('Render', () => {
     expect(actual).to.equal('JasonEtcodefunkt')
   })
 
+  it('returns an empty string if the value is falsy', async () => {
+    const context = { users: undefined }
+    const actual = await engine.parseAndRender('{% render "render-object" for users as user %}', context)
+    expect(actual).to.equal('')
+  })
+
   it('renders the provided snippet with a quote in a variable', async () => {
     const actual = await engine.parseAndRender('{% render "include", name: \'My name is "Jason"\' %}')
     expect(actual).to.equal('My name is "Jason"')


### PR DESCRIPTION
Currently, `{% render for <value> as <key> %}` will throw an error if `value` is falsy (more specifically, doesn't have a `.length` property). This is different from the behavior of most tags - if the tag is used correctly but the value it targets doesn't exist, it'll just fail silently and output an empty string.

This PR adds a simple `if (!value) return` line to exit early if the value that we would normally loop over is falsy.