### PR TITLE
Add lstrip & rstrip functions

### DIFF
--- a/lib/liquid/standard_filters.js
+++ b/lib/liquid/standard_filters.js
@@ -139,6 +139,9 @@ module.exports = {
   escape_once: function (input) {
     return toString(input).replace(HTML_ESCAPE_ONCE_REGEXP, HTML_ESCAPE)
   },
+  lstrip: function(input) {
+    return input.trimLeft()
+  },
   strip_html: function (input) {
     return toString(input).replace(/<script[\s\S]*?<\/script>/g, '').replace(/<!--[\s\S]*?-->/g, '').replace(/<style[\s\S]*?<\/style>/g, '').replace(/<[^>]*?>/g, '')
   },
@@ -165,6 +168,9 @@ module.exports = {
   },
   remove_first: function (input, string) {
     return this.replace_first(input, string)
+  },
+  rstrip: function(input) {
+    return input.trimRight()
   },
   truncate: function (input, length = 50, truncateString = '...') {
     input = toString(input)


### PR DESCRIPTION
Adds lstrip and rstrip to bring closer to matching current Shopify Liquid standards: 
https://shopify.github.io/liquid/filters/lstrip/
https://shopify.github.io/liquid/filters/rstrip/
